### PR TITLE
docs(README): fix typo in plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [semantic-release](https://semantic-release.gitbook.io/semantic-release/) plug
 Install the plugin from npm:
 
 ```bash
-npm install --save-dev @artesssan-devs/sr-uv-plugin
+npm install --save-dev @artessan-devs/sr-uv-plugin
 ```
 
 ## Usage
@@ -23,7 +23,7 @@ Update your `.releaserc.json` to include the plugin:
     { "name": "dev", "prerelease": true }
   ],
   "plugins": [
-    "@artesssan-devs/sr-uv-plugin",
+    "@artessan-devs/sr-uv-plugin",
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/npm",


### PR DESCRIPTION

This PR fixes the name of the plugin as shown in the README where there appears to be one "s" too many.

## Motivation

Copy-pasting the REAMDE's command led to:

```bash
> npm install --save-dev @artesssan-devs/sr-uv-plugin 
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@artesssan-devs%2fsr-uv-plugin - Not found
npm error 404
npm error 404  '@artesssan-devs/sr-uv-plugin@*' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
npm error A complete log of this run can be found in: ****REDACTED*****
```

The command on the right side of the official [NPM page](https://www.npmjs.com/package/@artessan-devs/sr-uv-plugin) is `npm i @artessan-devs/sr-uv-plugin` --> `artessan` with 2 "s", not 3

Then, using the same command as above with one less "s" led to:

```bash
npm install --save-dev @artessan-devs/sr-uv-plugin 

added 2 packages, and audited 695 packages in 5s

120 packages are looking for funding
  run `npm fund` for details

5 low severity vulnerabilities

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
```

which is expected behavior for a successful installation.

Hope it helps!
